### PR TITLE
This fixes the bug when hitting the decimal after an action button without a preceding 0.

### DIFF
--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -328,6 +328,10 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // evaluating decimal separator
           if (value === decimalSeparator) {
+            if(!stack.value && stack.trailing === "."){
+              stack.text = "0";
+              stack.value = "0"
+            }
             console.log('decimal')
             console.log(stack)
             if (

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -451,7 +451,6 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                   }
 
                   if (trailing !== '') {
-                    console.log(trailing)
                     stack.trailing = trailing.slice(0, trailing.length - 1)
                   } else {
                     if (value.length <= 1) {
@@ -461,23 +460,20 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
                       while (value.slice(-1) === '0') {
                         value = value.slice(0, value.length - 1)
-                        console.log(value)
                         trailing = trailing + '0'
-                        console.log(trailing)
                       }
 
                       // keep decimal separator displayed
-                      let sep = ''
-                      if (value[value.length - 1] === '.') {
-                        console.log('here')
-                        sep = this.props.decimalSeparator as string
-                      }
+                      // let sep = ''
+                      // if (value[value.length - 1] === '.') {
+                      //   sep = this.props.decimalSeparator as string
+                      // }
 
                       // get editing value
                       const val = parseFloat(
                         value.replace(decimalSeparator as string, '.')
                       )
-                      console.log(stack.value)
+
                       stack.value = val.toString()
                       stack.text = this.format(val)
                       stack.trailing = sep + trailing

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -464,10 +464,10 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                       }
 
                       // keep decimal separator displayed
-                      // let sep = ''
-                      // if (value[value.length - 1] === '.') {
-                      //   sep = this.props.decimalSeparator as string
-                      // }
+                      let sep = ''
+                      if (value[value.length - 1] === '.') {
+                        sep = this.props.decimalSeparator as string
+                      }
 
                       // get editing value
                       const val = parseFloat(

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -238,12 +238,12 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                 {this.renderNumberButton(btnSize, '000', false, 2)}
               </View>
             ) : (
-                <View style={Styles.row}>
-                  {this.renderNumberButton(btnSize, '0', true)}
-                  {this.renderNumberButton(btnSize, '000')}
-                  {!noDecimal &&
-                    this.renderNumberButton(btnSize, decimalSeparator as string)}
-                </View>
+              <View style={Styles.row}>
+                {this.renderNumberButton(btnSize, '0', true)}
+                {this.renderNumberButton(btnSize, '000')}
+                {!noDecimal &&
+                  this.renderNumberButton(btnSize, decimalSeparator as string)}
+              </View>
               )}
           </View>
           <Button
@@ -324,20 +324,12 @@ export class Calculator extends React.Component<CalculatorProps, State> {
             }
             this.stacks.push(stack)
           }
-          console.log(this.stacks)
+
           // evaluating decimal separator
           if (value === decimalSeparator) {
-            console.log(stack, "stack")
-            console.log(stack.trailing as string, "trailing")
-            console.log(stack.value as string, "value")
-            console.log(stack.text as string, "text")
-            if(!stack.value){
-              stack.text = "0";
+            if(!stack.value && !stack.text){
+              stack.text = "0"
               stack.value = "0"
-              console.log('here2')
-            }
-            if(stack.trailing == "."){
-              console.log('here')
             }
             if (
               stack.value.indexOf(decimalSeparator) > -1 ||
@@ -348,7 +340,6 @@ export class Calculator extends React.Component<CalculatorProps, State> {
             }
             stack.trailing = decimalSeparator
           } else if (value === '0' || value === '000') {
-            console.log('decimal 1')
             if (
               stack.value.indexOf(decimalSeparator as string) > -1 ||
               stack.trailing !== ''
@@ -357,7 +348,6 @@ export class Calculator extends React.Component<CalculatorProps, State> {
               value = ''
             }
           } else {
-            console.log('decimal 2')
             if (stack.trailing) {
               value = stack.trailing + value
               stack.trailing = ''
@@ -372,7 +362,6 @@ export class Calculator extends React.Component<CalculatorProps, State> {
           // modify current stack
           stack.value = val.toString()
           stack.text = this.format(val)
-          console.log(stack, "final stack")
           this.setText()
         }}
       />

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -328,10 +328,14 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // evaluating decimal separator
           if (value === decimalSeparator) {
-            if(stack.value !== stack.value && stack.trailing === "."){
+            if(stack.value === "NaN"){
               stack.text = "0";
               stack.value = "0"
               console.log('decimal')
+              console.log(stack)
+            }
+            if(stack.trailing === "."){
+              console.log('here')
               console.log(stack)
             }
             if (

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -316,7 +316,6 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // add new stack if current tag is a sign
           if (stack.kind === StackKindEnum.SIGN) {
-            console.log('stack')
             stack = {
               kind: StackKindEnum.NUMBER,
               value: '',
@@ -325,11 +324,14 @@ export class Calculator extends React.Component<CalculatorProps, State> {
             }
             this.stacks.push(stack)
           }
-
+          console.log(this.stacks)
           // evaluating decimal separator
           if (value === decimalSeparator) {
-            console.log(stack)
-            if(stack.value == "NaN"){
+            console.log(stack, "stack")
+            console.log(stack.trailing, "trailing")
+            console.log(stack.value, "value")
+            console.log(stack.text, "text")
+            if(!!stack.value){
               stack.text = "0";
               stack.value = "0"
               console.log('here2')
@@ -370,6 +372,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
           // modify current stack
           stack.value = val.toString()
           stack.text = this.format(val)
+          console.log(stack, "final stack")
           this.setText()
         }}
       />

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -238,13 +238,13 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                 {this.renderNumberButton(btnSize, '000', false, 2)}
               </View>
             ) : (
-              <View style={Styles.row}>
-                {this.renderNumberButton(btnSize, '0', true)}
-                {this.renderNumberButton(btnSize, '000')}
-                {!noDecimal &&
-                  this.renderNumberButton(btnSize, decimalSeparator as string)}
-              </View>
-            )}
+                <View style={Styles.row}>
+                  {this.renderNumberButton(btnSize, '0', true)}
+                  {this.renderNumberButton(btnSize, '000')}
+                  {!noDecimal &&
+                    this.renderNumberButton(btnSize, decimalSeparator as string)}
+                </View>
+              )}
           </View>
           <Button
             style={[
@@ -316,6 +316,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // add new stack if current tag is a sign
           if (stack.kind === StackKindEnum.SIGN) {
+            console.log('stack')
             stack = {
               kind: StackKindEnum.NUMBER,
               value: '',
@@ -327,6 +328,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // evaluating decimal separator
           if (value === decimalSeparator) {
+            console.log('decimal')
             if (
               stack.value.indexOf(decimalSeparator) > -1 ||
               stack.value === 'Infinity' ||
@@ -336,6 +338,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
             }
             stack.trailing = decimalSeparator
           } else if (value === '0' || value === '000') {
+            console.log('decimal 1')
             if (
               stack.value.indexOf(decimalSeparator as string) > -1 ||
               stack.trailing !== ''
@@ -344,6 +347,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
               value = ''
             }
           } else {
+            console.log('decimal 2')
             if (stack.trailing) {
               value = stack.trailing + value
               stack.trailing = ''

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -329,6 +329,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
           // evaluating decimal separator
           if (value === decimalSeparator) {
             console.log('decimal')
+            console.log(stack)
             if (
               stack.value.indexOf(decimalSeparator) > -1 ||
               stack.value === 'Infinity' ||

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -451,6 +451,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                   }
 
                   if (trailing !== '') {
+                    console.log(trailing)
                     stack.trailing = trailing.slice(0, trailing.length - 1)
                   } else {
                     if (value.length <= 1) {
@@ -460,12 +461,15 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
                       while (value.slice(-1) === '0') {
                         value = value.slice(0, value.length - 1)
+                        console.log(value)
                         trailing = trailing + '0'
+                        console.log(trailing)
                       }
 
                       // keep decimal separator displayed
                       let sep = ''
                       if (value[value.length - 1] === '.') {
+                        console.log('here')
                         sep = this.props.decimalSeparator as string
                       }
 
@@ -473,7 +477,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                       const val = parseFloat(
                         value.replace(decimalSeparator as string, '.')
                       )
-
+                      console.log(stack.value)
                       stack.value = val.toString()
                       stack.text = this.format(val)
                       stack.trailing = sep + trailing

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -244,7 +244,7 @@ export class Calculator extends React.Component<CalculatorProps, State> {
                 {!noDecimal &&
                   this.renderNumberButton(btnSize, decimalSeparator as string)}
               </View>
-              )}
+            )}
           </View>
           <Button
             style={[

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -328,15 +328,14 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // evaluating decimal separator
           if (value === decimalSeparator) {
-            if(stack.value === "NaN"){
+            console.log(stack)
+            if(stack.value == "NaN"){
               stack.text = "0";
               stack.value = "0"
-              console.log('decimal')
-              console.log(stack)
+              console.log('here2')
             }
-            if(stack.trailing === "."){
+            if(stack.trailing == "."){
               console.log('here')
-              console.log(stack)
             }
             if (
               stack.value.indexOf(decimalSeparator) > -1 ||

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -328,12 +328,12 @@ export class Calculator extends React.Component<CalculatorProps, State> {
 
           // evaluating decimal separator
           if (value === decimalSeparator) {
-            if(!stack.value && stack.trailing === "."){
+            if(stack.value !== stack.value && stack.trailing === "."){
               stack.text = "0";
               stack.value = "0"
+              console.log('decimal')
+              console.log(stack)
             }
-            console.log('decimal')
-            console.log(stack)
             if (
               stack.value.indexOf(decimalSeparator) > -1 ||
               stack.value === 'Infinity' ||

--- a/src/Calculator.tsx
+++ b/src/Calculator.tsx
@@ -328,10 +328,10 @@ export class Calculator extends React.Component<CalculatorProps, State> {
           // evaluating decimal separator
           if (value === decimalSeparator) {
             console.log(stack, "stack")
-            console.log(stack.trailing, "trailing")
-            console.log(stack.value, "value")
-            console.log(stack.text, "text")
-            if(!!stack.value){
+            console.log(stack.trailing as string, "trailing")
+            console.log(stack.value as string, "value")
+            console.log(stack.text as string, "text")
+            if(!stack.value){
               stack.text = "0";
               stack.value = "0"
               console.log('here2')


### PR DESCRIPTION
Removes the NaN bug from hitting the decimal button after an action button without a preceding 0. Not sure if you have a better way to do this. But essentially sets stack.value and stack.text to "0" if the there is no current stack.text or stack.value and the decimal button is hit.