### PR TITLE
fixing buttons click delay

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -22,7 +22,9 @@ export class Button extends React.Component<ButtonProps> {
     const { style, text, textStyle, onPress } = this.props
 
     return (
-      <TouchableOpacity style={[style]} onPressIn={onPress}>
+      <TouchableOpacity
+        delayPressIn = {0}
+        style={[style]} onPressIn={onPress}>
         <View style={styles.container}>
           <Text style={textStyle}>{text}</Text>
         </View>


### PR DESCRIPTION
i had a a problem using this calculator on android version , for tablet and even normal phone !
when i perform a button click most of times froze and i need to make a long press to select something .
i fixed that now using a property for the touchable opacity /* delayPressIn = {0} */